### PR TITLE
Remove site_name from default templatetag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+3.2.0
+~~~~~
+ * Dropped site name from default tags
+
 3.0.0
 ~~~~~
  * Added title tag

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ Changelog
 
 3.2.0
 ~~~~~
- * Dropped site name from default tags
+ * Dropped site_name from being added to the title by default
 
 3.0.0
 ~~~~~

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='wagtail-metadata',
-    version='3.1.0',
+    version='3.2.0',
     description="A tool to assist with metadata for social media.",
     long_description=readme,
     author='Neon Jungle',

--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -1,7 +1,7 @@
 {% block tags %}
 {% block twitter %}
 <meta name="twitter:card" content="{{ object.get_meta_twitter_card_type }}">
-<meta name="twitter:title" content="{{ object.get_meta_title }} — {{ site_name }}">
+<meta name="twitter:title" content="{{ object.get_meta_title }}">
 <meta name="twitter:description" content="{{ object.get_meta_description }}">
 {% if meta_image %}<meta name="twitter:image" content="{{ meta_image }}">{% endif %}
 {% endblock twitter %}
@@ -16,7 +16,7 @@
 
 {% block meta %}
 <meta itemprop='url' content='{{ object.get_meta_url }}'/>
-<meta itemprop="name" content="{{ object.get_meta_title }} — {{ site_name }}">
+<meta itemprop="name" content="{{ object.get_meta_title }}">
 <meta itemprop='description' content='{{ object.get_meta_description }}' />
 {% if meta_image %}<meta itemprop='image' content='{{meta_image}}' />{% endif %}
 


### PR DESCRIPTION
Fixes #56

This is better left up to the developer if they want to add the site name, at the moment it's a bit of a pain to override since it's not part of the `object.get_meta_title` you would have to override the whole block to remove it.