### PR TITLE
Updates to get tests passing again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 venv/
 build/
 .vscode
+tests/media/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: python
 cache: pip
 
-matrix:
-  include:
-    - env: TOXENV="py35-{dj20,dj21}-wt26"
-      python: '3.5'
-    - env: TOXENV="py36-{dj20,dj21}-wt26"
-      python: '3.6'
-    - env: TOXENV="flake8,isort,docs"
-      python: '3.6'
+python:
+ - "3.5"
+ - "3.6"
+ - "3.7"
+ - "3.8"
 
 install:
-  - pip install --upgrade pip wheel tox
+ - pip install --upgrade pip wheel tox-travis
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
 cache: pip
 
-python:
- - "3.5"
- - "3.6"
- - "3.7"
- - "3.8"
+matrix:
+  include:
+    - python: "3.5"
+    - python: "3.6"
+    - python: "3.7"
+    - python: "3.8"
+    - env: TOXENV="flake8,isort,docs"
+      python: "3.6"
 
 install:
- - pip install --upgrade pip wheel tox-travis
+  - pip install --upgrade pip wheel tox-travis
 
 script:
   - tox

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 wagtail-metadata
 ================
 
+.. image:: https://travis-ci.org/neon-jungle/wagtail-metadata.svg?branch=master
+    :target: https://travis-ci.org/neon-jungle/wagtail-metadata
+
 This plugin adds custom properties to your page models and then lets you output meta-attribute tags  using the included template tag.
 These tags help with search engine optimisations and for creating nice shareable links for social media, mainly Facebook and Twitter.
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import six
 from wagtail.core.models import Page
 
 from wagtailmetadata.models import MetadataMixin, MetadataPageMixin
@@ -10,7 +9,7 @@ class TestPageBase(type(Page)):
     pass
 
 
-class TestPage(six.with_metaclass(TestPageBase, MetadataPageMixin, Page)):
+class TestPage(MetadataPageMixin, Page, metaclass=TestPageBase):
     pass
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -56,7 +56,7 @@ class TemplateCase(object):
         }), out)
         self.assertInHTML(self.meta({
             'name': 'twitter:title',
-            'content': self.page.get_meta_title() + ' — ' + self.site.site_name,
+            'content': self.page.get_meta_title(),
         }), out)
         self.assertInHTML(self.meta({
             'name': 'twitter:description', 'content': self.page.search_description,
@@ -106,7 +106,7 @@ class TemplateCase(object):
         }), out)
         self.assertInHTML(self.meta({
             'itemprop': 'name',
-            'content': self.page.get_meta_title() + ' — ' + self.site.site_name,
+            'content': self.page.get_meta_title(),
         }), out)
         self.assertInHTML(self.meta({
             'itemprop': 'description', 'content': self.page.search_description,
@@ -130,7 +130,7 @@ class TemplateCase(object):
         }), out)
         self.assertInHTML(self.meta({
             'itemprop': 'name',
-            'content': self.test_model.get_meta_title() + ' — ' + self.site.site_name,
+            'content': self.test_model.get_meta_title(),
         }), out)
         self.assertInHTML(self.meta({
             'itemprop': 'description',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{35,36,37,38}-dj{22,30,31,HEAD}-wt{26,210,HEAD}
+	py{35}-dj{22}-wt{26}
+	py{36,37,38}-dj{22,30,31,HEAD}-wt{26,210,HEAD}
 	flake8,isort,docs
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	py35-{dj20,dj21}-wt26
-	py36-{dj20,dj21}-wt26
+	py{35,36,37,38}-dj{22,30,31,HEAD}-wt{26,210,HEAD}
 	flake8,isort,docs
 
 [testenv]
@@ -11,10 +10,12 @@ commands = python runtests.py {posargs}
 
 deps =
 	-rrequirements-dev.txt
-	dj20: django~=2.0.0
-	dj21: django~=2.1.0
+	dj22: django~=2.2.0
+	dj30: django~=3.0.0
+	dj31: django~=3.1.0
 	djHEAD: django
 	wt26: Wagtail~=2.6.0
+	wt210: Wagtail~=2.10.0
 	wtHEAD: Wagtail
 
 [testenv:flake8]


### PR DESCRIPTION
```
[x] - Deprecate six hooks since python 2.7 isn't supported anymore
[x] - Update tests to reflect site_name changes in 3.2
[x] - Add newer versions of python, django, and wagtail to tox
[x] - Use tox-travis to simplify the .travis.yml (slightly more DRY test config)
[x] - Add badge to the README
```

Here's the travis link for the build associated with this PR: https://travis-ci.org/github/m3brown/wagtail-metadata/builds/723477678

I added django and wagtail HEAD tests back into the matrix because the variables were there (unused), but I imagine there's a reason they were inactive. If you'd like, we can remove HEAD for django and/or wagtail, or look into making them fail silently.