### PR TITLE
add width and height to OG metaimage

### DIFF
--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -27,8 +27,13 @@ def meta_tags(request, model):
 
     meta_image = model.get_meta_image()
     if meta_image:
+        meta_image_width = meta_image.width
+        meta_image_height = meta_image.height
         meta_image = get_meta_image_url(request, meta_image)
+    context['meta_image_width'] = meta_image_width
+    context['meta_image_height'] = meta_image_height
     context['meta_image'] = meta_image
+
 
     return render_to_string('wagtailmetadata/parts/tags.html',
                             context, request=request)

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -30,9 +30,7 @@ def meta_tags(request, model):
         context['meta_image_width'] = meta_image.width
         context['meta_image_height'] = meta_image.height
         meta_image = get_meta_image_url(request, meta_image)
-
     context['meta_image'] = meta_image
-
 
     return render_to_string('wagtailmetadata/parts/tags.html',
                             context, request=request)

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -27,11 +27,10 @@ def meta_tags(request, model):
 
     meta_image = model.get_meta_image()
     if meta_image:
-        meta_image_width = meta_image.width
-        meta_image_height = meta_image.height
+        context['meta_image_width'] = meta_image.width
+        context['meta_image_height'] = meta_image.height
         meta_image = get_meta_image_url(request, meta_image)
-    context['meta_image_width'] = meta_image_width
-    context['meta_image_height'] = meta_image_height
+
     context['meta_image'] = meta_image
 
 

--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -11,7 +11,11 @@
 <meta property="og:title" content="{{ object.get_meta_title }}" />
 <meta property="og:description" content="{{ object.get_meta_description }}" />
 <meta property="og:site_name" content="{{ site_name }}" />
-{% if meta_image %}<meta property="og:image" content="{{ meta_image }}" />{% endif %}
+{% if meta_image %}
+<meta property="og:image" content="{{ meta_image }}" />
+<meta property="og:image:width" content="{{ meta_image_width }}" />
+<meta property="og:image:height" content="{{ meta_image_height }}" />
+{% endif %}
 {% endblock opengraph %}
 
 {% block meta %}


### PR DESCRIPTION
According to [Facebook](https://developers.facebook.com/docs/sharing/best-practices):

> Use og:image:width and og:image:height Open Graph tags to specify the image dimensions to the crawler so that it can render the image immediately without having to asynchronously download and process it.

I usually do this manually using: 

```
<meta property="og:image:width" content="{{ page.search_image.width }}" />
<meta property="og:image:height" content="{{ page.search_image.height }}" />    
```

So,  I thought I can add it directly to `templates/wagtailmetadata/parts/tags.html`.