### PR TITLE
get_meta_image_url for non-wagtail images

### DIFF
--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
+from django.conf import settings
 
 from .utils import get_image_model_string
 
@@ -29,6 +30,9 @@ class MetadataMixin(object):
         Get the image to use for this object.
         Can be None if there is no relevant image.
         """
+        return None
+
+    def get_meta_image_url(self, request):
         return None
 
     def get_meta_twitter_card_type(self):
@@ -76,6 +80,14 @@ class MetadataPageMixin(MetadataMixin, models.Model):
 
     def get_meta_image(self):
         return self.search_image
+
+    def get_meta_image_url(self, request):
+        meta_image = self.get_meta_image()
+        if meta_image:
+            filter = getattr(settings, "WAGTAILMETADATA_IMAGE_FILTER", "original")
+            rendition = self.get_meta_image().get_rendition(filter=filter)
+            return request.build_absolute_uri(rendition.url)
+        return None
 
     class Meta:
         abstract = True

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -3,16 +3,6 @@ from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
 from wagtail.core.models import Site
 
-
-def get_meta_image_url(request, image):
-    """
-    Resize an image for metadata tags, and return an absolute URL to it.
-    """
-    filter = getattr(settings, "WAGTAILMETADATA_IMAGE_FILTER", "original")
-    rendition = image.get_rendition(filter=filter)
-    return request.build_absolute_uri(rendition.url)
-
-
 def meta_tags(request, model):
     if not request:
         raise TemplateSyntaxError(
@@ -24,12 +14,11 @@ def meta_tags(request, model):
         'site_name': Site.find_for_request(request).site_name,
         'object': model,
     }
-
     meta_image = model.get_meta_image()
     if meta_image:
         context['meta_image_width'] = meta_image.width
         context['meta_image_height'] = meta_image.height
-        meta_image = get_meta_image_url(request, meta_image)
+        meta_image = model.get_meta_image_url(request)
     context['meta_image'] = meta_image
 
     return render_to_string('wagtailmetadata/parts/tags.html',


### PR DESCRIPTION
I understood that wagtail-metadata can be used with a non-page model. So I was using something like:

```
from sorl.thumbnail import ImageField

class User(MetadataMixin, AbstractUser):
    avatar = ImageField(upload_to="avatars", blank=False, default="images/image.png")  

    def get_meta_image(self):
        return self.avatar
```

Then I realized that [get_rendition()](https://github.com/neon-jungle/wagtail-metadata/blob/7bb42ffddbe9203ba5b07a17785f2d80cea58652/wagtailmetadata/tags.py#L12) is specific to Wagtail Image objects.

The code above will generate `'ImageFieldFile' object has no attribute 'get_rendition'` error. Shouldn't we treat non-pages models differently at this level?

```
    if hasattr(image, 'get_rendition'):
        filter = getattr(settings, "WAGTAILMETADATA_IMAGE_FILTER", "original")
        rendition = image.get_rendition(filter=filter)
        return request.build_absolute_uri(rendition.url)
    else:
        return request.build_absolute_uri(image.url)
```

Another helpful solution (in my case) is checking if the image instance is a Wagtail image using something like `isinstance(image, "Wagtail image class")`

Not sure if this suggestion is helpful, but let me know.         
