### PR TITLE
WT Image Mixin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-3.3.2
+3.4.0
 ~~~~~
 
  * Added overwritable `get_meta_image_url` method for non-wagtail meta images
+ * Split out Wagtail image related methods into own mixin `WagtailImageMetadataMixin`
 
 3.3.1
 ~~~~~

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.3.2
+~~~~~
+
+ * Added overwritable `get_meta_image_url` method for non-wagtail meta images
+
 3.3.1
 ~~~~~
  * Added width and height to share image attributes

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ You will need to implement the following methods:
             """
             Return a url for an image to use, see the MetadataPageMixin if using a Wagtail image
             """
-            return 'https://neonjungle.studio/share'
+            return 'https://neonjungle.studio/share.png'
 
         def get_meta_twitter_card_type(self):
             """
@@ -100,7 +100,7 @@ You will need to implement the following methods:
             return "summary_large_photo"
 
 If your custom object uses Wagtail images, you may wish to use the intermediary mixin ``wagtailmetadata.models.WagtailImageMetadataMixin``
-so you can use it for the image related metadata:
+so you can use the relationship for the image related metadata:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,6 @@ You will need to implement the following methods:
     from wagtailmetadata.models import MetadataMixin
 
     class CustomObject(MetadataMixin, object):
-
         def get_meta_title(self):
             """The title of this object"""
             return "My custom object"
@@ -86,9 +85,11 @@ You will need to implement the following methods:
             """
             return "This thing is really cool, you should totally check it out"
 
-        def get_meta_image(self):
-            """A relevant Wagtail Image to show. Optional."""
-            return self.some_image
+        def get_meta_image_url(self):
+            """
+            Return a url for an image to use, see the MetadataPageMixin if using a Wagtail image
+            """
+            return 'https://neonjungle.studio/share'
 
         def get_meta_twitter_card_type(self):
             """

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,20 @@ You will need to implement the following methods:
             """
             return "summary_large_photo"
 
+If your custom object uses Wagtail images, you may wish to use the intermediary mixin ``wagtailmetadata.models.WagtailImageMetadataMixin``
+so you can use it for the image related metadata:
+
+.. code-block:: python
+
+    from django.db import models
+    from wagtailmetadata.models import WagtailImageMetadataMixin
+    
+    class CustomObject(WagtailImageMetadataMixin, object):
+        share_image = models.ForeignKey('wagtailimages.Image', ondelete=models.SET_NULL, null=True, related_name='+')
+
+        def get_meta_image(self):
+            return self.share_image
+
 
 Display
 =======

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -23,5 +23,5 @@ class TestModel(MetadataMixin, models.Model):
     def get_meta_description(self):
         return 'Wagtail 101 - A journey through a CMS (Corrective Monkey Surgery)'
 
-    def get_meta_image(self):
+    def get_meta_image_url(self, request):
         return None

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,5 +1,3 @@
-
-
 from django.test import TestCase
 from wagtail.core.models import Site
 from wagtail.images.models import Image
@@ -40,6 +38,7 @@ class TestMetadataPageMixin(TestCase):
             'Some test content description')
 
     def test_image(self):
+        rendition = self.image.get_rendition('original')
         self.assertEqual(
             self.page.get_meta_image(),
-            self.image)
+            rendition)

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -38,7 +38,6 @@ class TestMetadataPageMixin(TestCase):
             'Some test content description')
 
     def test_image(self):
-        rendition = self.image.get_rendition('original')
         self.assertEqual(
             self.page.get_meta_image(),
-            rendition)
+            self.test_image)

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -40,4 +40,4 @@ class TestMetadataPageMixin(TestCase):
     def test_image(self):
         self.assertEqual(
             self.page.get_meta_image(),
-            self.test_image)
+            self.image)

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -38,14 +38,14 @@ class MetadataMixin(object):
         """
         return None, None
 
-    def get_meta_twitter_card_type(self):
+    def get_twitter_card_type(self, request):
         """
         Get the Twitter card type for this object.
         See https://dev.twitter.com/cards/types.
-        Defaults to 'summary_large_image' if the object has an image,
+        Defaults to 'summary' if the object has an image,
         otherwise 'summary'.
         """
-        if self.get_meta_image() is not None:
+        if self.get_meta_image_url(request) is not None:
             return 'summary_large_image'
         else:
             return 'summary'

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -1,8 +1,8 @@
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
-from django.conf import settings
 
 from .utils import get_image_model_string
 
@@ -71,7 +71,7 @@ class WagtailImageMetadataMixin(MetadataMixin):
         if meta_image:
             return request.build_absolute_uri(meta_image.url)
         return None
-    
+
     def get_meta_image_dimensions(self):
         meta_image = self.get_meta_image_rendition()
         if meta_image:

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -25,15 +25,18 @@ class MetadataMixin(object):
     def get_meta_description(self):
         raise NotImplementedError()
 
-    def get_meta_image(self):
+    def get_meta_image_url(self, request):
         """
         Get the image to use for this object.
         Can be None if there is no relevant image.
         """
         return None
 
-    def get_meta_image_url(self, request):
-        return None
+    def get_meta_image_dimensions(self):
+        """
+        Return width, height (in pixels
+        """
+        return None, None
 
     def get_meta_twitter_card_type(self):
         """
@@ -79,15 +82,23 @@ class MetadataPageMixin(MetadataMixin, models.Model):
         return self.search_description
 
     def get_meta_image(self):
-        return self.search_image
+        if self.search_image:
+            filter = getattr(settings, "WAGTAILMETADATA_IMAGE_FILTER", "original")
+            rendition = self.search_image.get_rendition(filter=filter)
+            return rendition
+        return None
 
     def get_meta_image_url(self, request):
         meta_image = self.get_meta_image()
         if meta_image:
-            filter = getattr(settings, "WAGTAILMETADATA_IMAGE_FILTER", "original")
-            rendition = self.get_meta_image().get_rendition(filter=filter)
-            return request.build_absolute_uri(rendition.url)
+            return request.build_absolute_uri(meta_image.url)
         return None
+    
+    def get_meta_image_dimensions(self):
+        meta_image = self.get_meta_image()
+        if meta_image:
+            return meta_image.width, meta_image.height
+        return None, None
 
     class Meta:
         abstract = True

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -1,7 +1,7 @@
-from django.conf import settings
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
 from wagtail.core.models import Site
+
 
 def meta_tags(request, model):
     if not request:
@@ -14,11 +14,12 @@ def meta_tags(request, model):
         'site_name': Site.find_for_request(request).site_name,
         'object': model,
     }
-    meta_image = model.get_meta_image()
+
+    meta_image = model.get_meta_image_url(request)
     if meta_image:
-        context['meta_image_width'] = meta_image.width
-        context['meta_image_height'] = meta_image.height
-        meta_image = model.get_meta_image_url(request)
+        width, height = model.get_meta_image_dimensions()
+        context['meta_image_width'] = width
+        context['meta_image_height'] = height
     context['meta_image'] = meta_image
 
     return render_to_string('wagtailmetadata/parts/tags.html',

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -12,6 +12,7 @@ def meta_tags(request, model):
             "'meta_tags' tag is missing a model or object")
     context = {
         'site_name': Site.find_for_request(request).site_name,
+        'twitter_card_type': model.get_twitter_card_type(request),
         'object': model,
     }
 

--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -13,8 +13,10 @@
 <meta property="og:site_name" content="{{ site_name }}" />
 {% if meta_image %}
 <meta property="og:image" content="{{ meta_image }}" />
+{% if meta_image_width and meta_image_height %}
 <meta property="og:image:width" content="{{ meta_image_width }}" />
 <meta property="og:image:height" content="{{ meta_image_height }}" />
+{% endif %}
 {% endif %}
 {% endblock opengraph %}
 

--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -1,6 +1,6 @@
 {% block tags %}
 {% block twitter %}
-<meta name="twitter:card" content="{{ object.get_meta_twitter_card_type }}">
+<meta name="twitter:card" content="{{ twitter_card_type }}">
 <meta name="twitter:title" content="{{ object.get_meta_title }}">
 <meta name="twitter:description" content="{{ object.get_meta_description }}">
 {% if meta_image %}<meta name="twitter:image" content="{{ meta_image }}">{% endif %}


### PR DESCRIPTION
This is building on #65, cleaning up a few things.

`get_meta_image` always assumed that you were working with a Wagtail image, which might not always be the case. So now the basic `MetadataMixin` only has a method called `get_meta_image_url`. The intermediary mixin `WagtailImageMetadataMixin` is now used basically like before, where `get_image` is assumed to return a Wagtail image.

Not sold on the name `WagtailImageMetadataMixin` so if there's something a bit shorter happy to change it.

