### PR TITLE
Add wagtail 3 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+4.0.0
+~~~~~
+
+ * Add Wagtail 3.0 support
+ * Drop support for wagtail 2.0
+
 3.5.0
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/neon-jungle/wagtail-metadata',
 
     install_requires=[
-        'wagtail~=2.0',
+        'wagtail~=3.0',
     ],
     zip_safe=False,
     license='BSD License',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='wagtail-metadata',
-    version='3.5.0',
+    version='4.0.0',
     description="A tool to assist with metadata for social media.",
     long_description=readme,
     author='Neon Jungle',

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,5 +1,8 @@
 from django.db import models
-from wagtail.core.models import Page
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 from wagtailmetadata.models import MetadataMixin, MetadataPageMixin
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,8 +1,5 @@
 from django.db import models
-try:
-    from wagtail.models import Page
-except ImportError:
-    from wagtail.core.models import Page
+from wagtail.models import Page
 
 from wagtailmetadata.models import MetadataMixin, MetadataPageMixin
 

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -2,7 +2,10 @@
 
 from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+try:
+    from wagtail import urls as wagtailadmin_urls
+except ImportError:
+    from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
     path('admin/', include(wagtailadmin_urls)),

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -2,10 +2,7 @@
 
 from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
-try:
-    from wagtail import urls as wagtailadmin_urls
-except ImportError:
-    from wagtail.core import urls as wagtail_urls
+from wagtail import urls as wagtail_urls
 
 urlpatterns = [
     path('admin/', include(wagtailadmin_urls)),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,11 @@
 import os
+from wagtail import VERSION as WAGTAIL_VERSION
 
 DEBUG = True
 
 SECRET_KEY = 'not a secret'
+
+WAGTAIL_CORE = "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core"
 
 INSTALLED_APPS = [
     # Local apps
@@ -21,7 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
 
     # Wagtail apps
-    'wagtail.core',
+    WAGTAIL_CORE,
     'wagtail.admin',
     'wagtail.documents',
     'wagtail.users',
@@ -52,7 +55,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
+    f'{WAGTAIL_CORE}.middleware.SiteMiddleware',
 ]
 
 TEMPLATES = [
@@ -78,7 +81,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'extensions': [
-                'wagtail.core.jinja2tags.core',
+                f'{WAGTAIL_CORE}.jinja2tags.core',
                 'wagtail.images.jinja2tags.images',
                 'wagtailmetadata.jinja2tags.WagtailMetadataExtension'
             ],

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,11 +1,8 @@
 import os
-from wagtail import VERSION as WAGTAIL_VERSION
 
 DEBUG = True
 
 SECRET_KEY = 'not a secret'
-
-WAGTAIL_CORE = "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core"
 
 INSTALLED_APPS = [
     # Local apps
@@ -24,7 +21,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
 
     # Wagtail apps
-    WAGTAIL_CORE,
+    'wagtail',
     'wagtail.admin',
     'wagtail.documents',
     'wagtail.users',
@@ -55,7 +52,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    f'{WAGTAIL_CORE}.middleware.SiteMiddleware',
+    'wagtail.middleware.SiteMiddleware',
 ]
 
 TEMPLATES = [
@@ -81,7 +78,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'extensions': [
-                f'{WAGTAIL_CORE}.jinja2tags.core',
+                'wagtail.jinja2tags.core',
                 'wagtail.images.jinja2tags.images',
                 'wagtailmetadata.jinja2tags.WagtailMetadataExtension'
             ],

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,8 +1,5 @@
 from django.test import TestCase
-try:
-    from wagtail.models import Site
-except:
-    from wagtail.core.models import Site
+from wagtail.models import Site
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,5 +1,8 @@
 from django.test import TestCase
-from wagtail.core.models import Site
+try:
+    from wagtail.models import Site
+except:
+    from wagtail.core.models import Site
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -2,7 +2,10 @@ from django.forms.utils import flatatt
 from django.template import TemplateSyntaxError, engines
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils.html import format_html
-from wagtail.core.models import Site
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -2,10 +2,7 @@ from django.forms.utils import flatatt
 from django.template import TemplateSyntaxError, engines
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils.html import format_html
-try:
-    from wagtail.models import Site
-except ImportError:
-    from wagtail.core.models import Site
+from wagtail.models import Site
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -1,10 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy
-try:
-    from wagtail.admin.panels import FieldPanel, MultiFieldPanel
-except ImportError:
-    from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
+from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from .utils import get_image_model_string

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -1,7 +1,10 @@
 from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy
-from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
+try:
+    from wagtail.admin.panels import FieldPanel, MultiFieldPanel
+except ImportError:
+    from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from .utils import get_image_model_string

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -2,7 +2,7 @@ from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
 try:
     from wagtail.models import Site
- except ImportError:
+except ImportError:
     from wagtail.core.models import Site
 
 

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -1,9 +1,6 @@
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
-try:
-    from wagtail.models import Site
-except ImportError:
-    from wagtail.core.models import Site
+from wagtail.models import Site
 
 
 def meta_tags(request, model):

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -1,6 +1,9 @@
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
-from wagtail.core.models import Site
+try:
+    from wagtail.models import Site
+ except ImportError:
+    from wagtail.core.models import Site
 
 
 def meta_tags(request, model):


### PR DESCRIPTION
Since wagtail 3 is out, imports from wagtail.core have changed 
This PR brings wagtail 3.0 support

I am using this branch on a real wagtail installation without issue so far. 