### PR TITLE
Add jinja 3 support

### DIFF
--- a/wagtailmetadata/jinja2tags.py
+++ b/wagtailmetadata/jinja2tags.py
@@ -1,16 +1,17 @@
 import jinja2
 from jinja2.ext import Extension
+import markupsafe
 
 from wagtailmetadata import tags
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def meta_tags(context, model=None):
     request = context.get('request', None)
     if not model:
         model = context.get('page', None)
 
-    return jinja2.Markup(tags.meta_tags(request, model))
+    return markupsafe.Markup(tags.meta_tags(request, model))
 
 
 class WagtailMetadataExtension(Extension):


### PR DESCRIPTION
Tests are currently failing with jinja 3 
These changes are not compatible with jinja 2

Related to https://github.com/neon-jungle/wagtail-metadata/issues/77