### PR TITLE
Remove deprecation warnings in Wagtail 4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+4.0.2
+~~~~~
+
+* Replace deprecated ImageChooserPanel with FieldPanel
+
+
 4.0.1
 ~~~~~
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Tim Heap - <tim@takeflight.com.au>
 David Lawson - <ddiranlawson@outlook.com>
 Johannes Vogel - <johannesvogel>
 Dani Hodovic - <danihodovic>
+Sean Kelly - <nutjob4life>

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
-from wagtail.images.edit_handlers import ImageChooserPanel
 
 from .utils import get_image_model_string
 
@@ -96,7 +95,7 @@ class MetadataPageMixin(WagtailImageMetadataMixin, models.Model):
             FieldPanel('seo_title'),
             FieldPanel('show_in_menus'),
             FieldPanel('search_description'),
-            ImageChooserPanel('search_image'),
+            FieldPanel('search_image'),
         ], gettext_lazy('Common page configuration')),
     ]
 


### PR DESCRIPTION
In [Wagtail 3.0](https://docs.wagtail.org/en/stable/reference/pages/panels.html#module-wagtail.images.edit_handlers), `ImageChooserPanel` was deprecated; plain `FieldPanel` is smart enough to handle regular and image fields now. In Wagtail 4.0, use of `ImageChooserPanel` produces `RemovedInWagtail50Warning`. This PR removes the use of `ImageChooserPanel`.
