### PR TITLE
Remove invalid tags.html

### DIFF
--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -20,13 +20,4 @@
 {% endif %}
 {% endblock opengraph %}
 
-{% block meta %}
-<meta itemprop="url" content="{{ object.get_meta_url }}">
-<meta itemprop="name" content="{{ object.get_meta_title }}">
-<meta itemprop="description" content="{{ object.get_meta_description }}">
-{% if meta_image %}<meta itemprop="image" content="{{meta_image}}">{% endif %}
-
-<title>{{ object.get_object_title }}</title>
-<meta name="description" content="{{ object.get_meta_description }}">
-{% endblock meta %}
 {% endblock tags %}


### PR DESCRIPTION
W3C validator : The itemprop attribute was specified, but the element is not a property of any item.